### PR TITLE
Fix homepage categories with tailwind

### DIFF
--- a/frontend/src/app/lib/homepageServices.ts
+++ b/frontend/src/app/lib/homepageServices.ts
@@ -1,4 +1,4 @@
-import { FlashDealsArraySchema, FlashDealRaw, FlashDeal } from './types';
+import { FlashDeal } from './types';
 
 // Mock data for development
 const MOCK_FLASH_DEALS: FlashDeal[] = [

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -53,15 +53,14 @@ export default async function Home() {
             </div>
           </div>
         </section>
-        <div className="products-categories-wrapper">
         <div className="mt-20">
   <section className="w-full mt-8">
-    <div className="grid grid-cols-[repeat(auto-fill,_minmax(350px,_1fr))] gap-0">
+      <div className="grid grid-cols-[repeat(auto-fill,_minmax(350px,_1fr))] gap-0">
       {phoneCards.map((card, index) => (
         <Link
           key={index}
           href={card.link}
-          className="border-b border-l border-gray-200 text-center py-[10px] px-[40px] w-full pb-[100px] hover:bg-gray-100 cursor-pointer transition-colors duration-100 ease-in"
+          className="border-b border-l border-[#f0f0f0] text-center py-[10px] px-[40px] w-full pb-[100px] hover:bg-[#f0f0f0] cursor-pointer transition-colors duration-100 ease-in"
         >
           <div className="flex flex-col items-center">
             <h2 className="mb-[10px] text-[1.2rem]">{card.name}</h2>
@@ -89,7 +88,7 @@ export default async function Home() {
         <Link
           key={index}
           href={card.link}
-          className="border-b border-x border-gray-200 text-center py-[10px] px-[40px] w-full mb-5 pb-[100px] hover:bg-gray-100 cursor-pointer transition-colors duration-100 ease-in"
+          className="border-b border-x border-[#f0f0f0] text-center py-[10px] px-[40px] w-full mb-5 pb-[100px] hover:bg-[#f0f0f0] cursor-pointer transition-colors duration-100 ease-in"
         >
           <div className="flex flex-col items-center">
             <h2 className="mb-[10px] text-[1.2rem]">{card.name}</h2>
@@ -110,7 +109,6 @@ export default async function Home() {
       ))}
     </div>
   </section>
-</div>
 </div>
         
       </main>


### PR DESCRIPTION
## Summary
- refactor homepage category/phone cards with Tailwind classes
- drop unused imports in homepage services

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688adc30fffc832d9d4ffe280949f61e