### PR TITLE
Expose product models for Django

### DIFF
--- a/backend/apps/products/models.py
+++ b/backend/apps/products/models.py
@@ -1,0 +1,9 @@
+"""Aggregate product models for Django's auto-discovery."""
+
+from .models.brand import Brand
+from .models.phone import Phone
+from .models.variant import PhoneVariant
+from .models.accessory import Accessory
+
+__all__ = ["Brand", "Phone", "PhoneVariant", "Accessory"]
+

--- a/backend/apps/products/models/__init__.py
+++ b/backend/apps/products/models/__init__.py
@@ -1,1 +1,9 @@
-# This file makes the models directory a Python package
+"""Expose concrete product models for Django."""
+
+from .brand import Brand
+from .phone import Phone
+from .variant import PhoneVariant
+from .accessory import Accessory
+
+__all__ = ["Brand", "Phone", "PhoneVariant", "Accessory"]
+


### PR DESCRIPTION
## Summary
- expose Brand, Phone, PhoneVariant and Accessory models via the products app so Django can discover them

## Testing
- `python manage.py test` *(fails: NameError: name 'models' is not defined in variant.py)*

------
https://chatgpt.com/codex/tasks/task_e_689108a23260832db908cdd66c8ea129