### PR TITLE
Expose product models for Django

### DIFF
--- a/backend/apps/products/models/__init__.py
+++ b/backend/apps/products/models/__init__.py
@@ -1,1 +1,19 @@
-# This file makes the models directory a Python package
+"""Model declarations for the products app.
+
+This module exposes the concrete product models so that Django's automatic
+model discovery (which imports ``<app>.models``) picks them up when the app is
+loaded. By importing the models here, we ensure that they are registered with
+the app registry.
+"""
+
+from .brand import Brand
+from .phone import Phone
+from .variant import PhoneVariant
+from .accessory import Accessory
+
+__all__ = [
+    "Brand",
+    "Phone",
+    "PhoneVariant",
+    "Accessory",
+]

--- a/backend/apps/products/models/variant.py
+++ b/backend/apps/products/models/variant.py
@@ -1,17 +1,24 @@
-from django.db.models.fields import related
+from django.db import models
 
+from .phone import Phone
 
 
 class PhoneVariant(models.Model):
+    """Represents a specific variant of a phone model."""
+
     phone = models.ForeignKey(
         Phone,
         on_delete=models.CASCADE,
-        related_name='variants'
+        related_name="variants",
     )
-    variant_name = model.CharField(max_length=100)
+    variant_name = models.CharField(max_length=100)
     price = models.DecimalField(max_digits=10, decimal_places=2)
     stock = models.PositiveIntegerField(default=0)
     is_active = models.BooleanField(default=True)
 
-    def __str__(self):
-        return f"{self.phone.name} - {self.variant_name}"
+    class Meta:
+        ordering = ["phone", "variant_name"]
+
+    def __str__(self) -> str:
+        return f"{self.phone} - {self.variant_name}"
+


### PR DESCRIPTION
## Summary
- expose product models by importing Brand, Phone, PhoneVariant and Accessory in the models package so Django auto-discovers them
- implement a proper PhoneVariant model for variants
- remove unused models.py that hid the models package

## Testing
- `python backend/manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689110535644832d932e74f4d8c600ac