### PR TITLE
Fix product model Meta classes

### DIFF
--- a/backend/apps/products/models/accessory.py
+++ b/backend/apps/products/models/accessory.py
@@ -16,7 +16,7 @@ class Accessory(AbstractProduct):
     accessory_type = models.CharField(max_length=50, choices=ACCESSORY_TYPES)
     compatible_with = models.ManyToManyField('Phone', related_name='compatible_accessories', blank=True)
     
-    class Meta(AbstractProduct.Meta):
+    class Meta:
         verbose_name_plural = 'Accessories'
         ordering = ['accessory_type', 'brand__name', 'name']
     

--- a/backend/apps/products/models/phone.py
+++ b/backend/apps/products/models/phone.py
@@ -12,7 +12,7 @@ class Phone(AbstractProduct):
     storage_capacity = models.PositiveIntegerField(help_text="Storage in GB")
     ram = models.PositiveIntegerField(help_text="RAM in GB")
     
-    class Meta(AbstractProduct.Meta):
+    class Meta:
         ordering = ['-release_year', 'brand__name', 'model']
     
     def __str__(self):


### PR DESCRIPTION
## Summary
- remove AbstractProduct Meta inheritance from Phone and Accessory models
- make both models concrete and preserve their ordering

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68912c767c00832d9669212e7f21f20e