### PR TITLE
Define repair and appointment models

### DIFF
--- a/backend/apps/appointments/migrations/0001_initial.py
+++ b/backend/apps/appointments/migrations/0001_initial.py
@@ -1,0 +1,35 @@
+# Generated manually for initial schema
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        ('repairs', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Appointment',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('customer_name', models.CharField(max_length=100)),
+                ('customer_email', models.EmailField(max_length=254)),
+                ('scheduled_for', models.DateTimeField()),
+                ('notes', models.TextField(blank=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                (
+                    'repair_price',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='appointments',
+                        to='repairs.repairprice',
+                    ),
+                ),
+            ],
+            options={'ordering': ['scheduled_for']},
+        ),
+    ]

--- a/backend/apps/appointments/models.py
+++ b/backend/apps/appointments/models.py
@@ -1,3 +1,24 @@
-from django.db import models
+"""Models related to booking repair appointments."""
 
-# Create your models here.
+from django.db import models
+from apps.repairs.models import RepairPrice
+
+
+class Appointment(models.Model):
+    """An appointment booked by a customer for a repair."""
+
+    repair_price = models.ForeignKey(
+        RepairPrice, related_name="appointments", on_delete=models.CASCADE
+    )
+    customer_name = models.CharField(max_length=100)
+    customer_email = models.EmailField()
+    scheduled_for = models.DateTimeField()
+    notes = models.TextField(blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["scheduled_for"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.customer_name} @ {self.scheduled_for:%Y-%m-%d %H:%M}"

--- a/backend/apps/repairs/migrations/0001_initial.py
+++ b/backend/apps/repairs/migrations/0001_initial.py
@@ -1,0 +1,37 @@
+# Generated manually for initial schema
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='RepairType',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100)),
+                ('description', models.TextField(blank=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='RepairPrice',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('device_name', models.CharField(max_length=100)),
+                ('price', models.DecimalField(decimal_places=2, max_digits=10)),
+                ('is_active', models.BooleanField(default=True)),
+                (
+                    'repair_type',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='prices',
+                        to='repairs.repairtype',
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/backend/apps/repairs/models.py
+++ b/backend/apps/repairs/models.py
@@ -1,3 +1,34 @@
+"""Database models for the ``repairs`` application.
+
+These simple models store the different types of repairs offered by the
+business and the price for each repair depending on the device.  They are
+intentionally lightweight so that other parts of the project – such as the
+``appointments`` app – can reference them without pulling in extra
+complexity.
+"""
+
 from django.db import models
 
-# Create your models here.
+
+class RepairType(models.Model):
+    """A category of repair, e.g. screen replacement or battery change."""
+
+    name = models.CharField(max_length=100)
+    description = models.TextField(blank=True)
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return self.name
+
+
+class RepairPrice(models.Model):
+    """Price information for a given repair and device."""
+
+    repair_type = models.ForeignKey(
+        RepairType, related_name="prices", on_delete=models.CASCADE
+    )
+    device_name = models.CharField(max_length=100)
+    price = models.DecimalField(max_digits=10, decimal_places=2)
+    is_active = models.BooleanField(default=True)
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.device_name} - {self.repair_type.name}"


### PR DESCRIPTION
## Summary
- add `RepairType` and `RepairPrice` models for storing repair details and pricing
- create `Appointment` model referencing repair prices for scheduling
- include initial migrations for repairs and appointments apps

## Testing
- `python3 manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68912d213b28832d8717109f0bed930e